### PR TITLE
brittany plugin: Enable syntactic extensions by default

### DIFF
--- a/hie-brittany/Haskell/Ide/BrittanyPlugin.hs
+++ b/hie-brittany/Haskell/Ide/BrittanyPlugin.hs
@@ -63,9 +63,15 @@ normalize (Range (Position sl _) (Position el _)) =
 
 runBrittany :: Int -> Text -> IO (Either [BrittanyError] Text)
 runBrittany tabSize text = do
-    let config' = staticDefaultConfig
-        config = config' { _conf_layout = (_conf_layout config') { _lconfig_indentAmount = coerce tabSize }}
-    parsePrintModule config text
+  let
+    config' = staticDefaultConfig
+    config  = config'
+      { _conf_layout = (_conf_layout config') { _lconfig_indentAmount = coerce
+                                                tabSize
+                                              }
+      , _conf_forward = _conf_forward config' <> forwardOptionsSyntaxExtsEnabled
+      }
+  parsePrintModule config text
 
 showErr :: BrittanyError -> String
 showErr (ErrorInput s) = s

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,7 +38,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/lspitzner/brittany.git
-    commit: 16f5aa118d707cc484cdee39351b176b6d17c3df
+    commit: 134f31e4d18e51a7cd3d5bcaa90af92e70b926ce
   extra-dep: true
 
 extra-deps:


### PR DESCRIPTION
compiles, but otherwise untested (my editor doesn't support lsp sufficiently well yet, i fear)